### PR TITLE
Change 401 redirects to 403

### DIFF
--- a/app/api/concerns/authenticator.rb
+++ b/app/api/concerns/authenticator.rb
@@ -3,7 +3,7 @@ module Authenticator
 
   included do
     before do
-      error!('401 Unauthorized', 401) unless authenticated
+      error!('403 Forbidden', 403) unless authenticated
     end
 
     helpers do

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,6 @@ class ApplicationController < ActionController::Base
   private
 
   def not_authorized
-    flash[:alert] = 'You are not authorized to do this.'
-    redirect_to(request.referrer || root_path, status: 401)
+    render file: 'public/403.html', status: 403
   end
 end

--- a/public/403.html
+++ b/public/403.html
@@ -1,0 +1,8 @@
+<div class="ui grid center aligned container">
+  <div class="nine wide column">
+    <div class="ui error message">
+      <h1>You are not authorized to do this.</h1>
+      <p>You should probably <a href='/'>return back home</a></p>
+    </div>
+  </div>
+</div>

--- a/spec/requests/app_requests_spec.rb
+++ b/spec/requests/app_requests_spec.rb
@@ -4,17 +4,17 @@ RSpec.feature 'app requests', type: :request do
       subject(:request) { get new_app_url }
 
       context 'role: guest' do
-        include_examples 'status code', 401
+        include_examples 'status code', 403
       end
 
       context 'role: user' do
         include_context 'login user'
-        include_examples 'status code', 401
+        include_examples 'status code', 403
       end
 
       context 'role: moderator' do
         include_context 'login moderator'
-        include_examples 'status code', 401
+        include_examples 'status code', 403
       end
 
       context 'role: admin' do
@@ -28,7 +28,7 @@ RSpec.feature 'app requests', type: :request do
 
         context 'admin has set #flag_stamps to true' do
           let(:flag_stamps) { false }
-          include_examples 'status code', 401
+          include_examples 'status code', 403
         end
       end
     end
@@ -40,17 +40,17 @@ RSpec.feature 'app requests', type: :request do
       end
 
       context 'role: guest' do
-        include_examples 'status code', 401
+        include_examples 'status code', 403
       end
 
       context 'role: user' do
         include_context 'login user'
-        include_examples 'status code', 401
+        include_examples 'status code', 403
       end
 
       context 'role: moderator' do
         include_context 'login moderator'
-        include_examples 'status code', 401
+        include_examples 'status code', 403
       end
 
       context 'role: admin' do
@@ -64,7 +64,7 @@ RSpec.feature 'app requests', type: :request do
 
         context 'admin has set #flag_stamps to true' do
           let(:flag_stamps) { false }
-          include_examples 'status code', 401
+          include_examples 'status code', 403
         end
       end
     end
@@ -76,17 +76,17 @@ RSpec.feature 'app requests', type: :request do
       let(:some_app) { FactoryBot.create(:app) }
 
       context 'role: guest' do
-        include_examples 'status code', 401
+        include_examples 'status code', 403
       end
 
       context 'role: user' do
         include_context 'login user'
-        include_examples 'status code', 401
+        include_examples 'status code', 403
       end
 
       context 'role: moderator' do
         include_context 'login moderator'
-        include_examples 'status code', 401
+        include_examples 'status code', 403
       end
 
       context 'role: admin' do
@@ -100,7 +100,7 @@ RSpec.feature 'app requests', type: :request do
 
         context 'admin has set #flag_stamps to true' do
           let(:flag_stamps) { false }
-          include_examples 'status code', 401
+          include_examples 'status code', 403
         end
       end
     end

--- a/spec/requests/comment_requests_spec.rb
+++ b/spec/requests/comment_requests_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'comment requests', type: :request do
       let(:comment_attributes) { { comment: { content: '1' * 40 } } }
 
       context 'role: guest' do
-        include_examples 'status code', 401
+        include_examples 'status code', 403
       end
 
       context 'role: user' do
@@ -20,22 +20,22 @@ RSpec.feature 'comment requests', type: :request do
 
         context 'state is :accepted' do
           let(:state) { :accepted }
-          include_examples 'status code', 401
+          include_examples 'status code', 403
         end
 
         context 'state is :archived' do
           let(:state) { :archived }
-          include_examples 'status code', 401
+          include_examples 'status code', 403
         end
 
         context 'state is :denied' do
           let(:state) { :denied }
-          include_examples 'status code', 401
+          include_examples 'status code', 403
         end
 
         context 'state is :disputed' do
           let(:state) { :disputed }
-          include_examples 'status code', 401
+          include_examples 'status code', 403
         end
       end
 

--- a/spec/requests/domain_requests_spec.rb
+++ b/spec/requests/domain_requests_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'domain requests', type: :request do
       subject(:request) { get new_domain_url }
 
       context 'role: guest' do
-        include_examples 'status code', 401
+        include_examples 'status code', 403
       end
 
       context 'role: user' do

--- a/spec/requests/notification_requests_spec.rb
+++ b/spec/requests/notification_requests_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'notification requests', type: :request do
       subject(:request) { post read_all_notifications_url, xhr: true }
 
       context 'role: guest' do
-        include_examples 'status code', 401
+        include_examples 'status code', 403
       end
 
       context 'role: user' do

--- a/spec/requests/stamp_requests_spec.rb
+++ b/spec/requests/stamp_requests_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'stamp requests', type: :request do
       let(:domain) { FactoryBot.create(:domain) }
 
       context 'role: guest' do
-        include_examples 'status code', 401
+        include_examples 'status code', 403
       end
 
       context 'role: user' do
@@ -36,7 +36,7 @@ RSpec.feature 'stamp requests', type: :request do
       end
 
       context 'role: guest' do
-        include_examples 'status code', 401
+        include_examples 'status code', 403
       end
 
       context 'role: user' do

--- a/spec/requests/user_requests_spec.rb
+++ b/spec/requests/user_requests_spec.rb
@@ -5,18 +5,18 @@ RSpec.feature 'user requests', type: :request do
       let(:targeted_user) { FactoryBot.create(:user) }
 
       context 'role: guest' do
-        include_examples 'status code', 401
+        include_examples 'status code', 403
       end
 
       context 'targeted user is random user' do
         context 'role: user' do
           include_context 'login user'
-          include_examples 'status code', 401
+          include_examples 'status code', 403
         end
 
         context 'role: moderator' do
           include_context 'login moderator'
-          include_examples 'status code', 401
+          include_examples 'status code', 403
         end
 
         context 'role: admin' do
@@ -54,18 +54,18 @@ RSpec.feature 'user requests', type: :request do
       let(:user_attributes) { FactoryBot.attributes_for(:user) }
 
       context 'role: guest' do
-        include_examples 'status code', 401
+        include_examples 'status code', 403
       end
 
       context 'targeted user is random user' do
         context 'role: user' do
           include_context 'login user'
-          include_examples 'status code', 401
+          include_examples 'status code', 403
         end
 
         context 'role: moderator' do
           include_context 'login moderator'
-          include_examples 'status code', 401
+          include_examples 'status code', 403
         end
 
         context 'role: admin' do

--- a/spec/requests/vote_requests_spec.rb
+++ b/spec/requests/vote_requests_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'vote requests', type: :request do
       let(:vote_attributes) { { vote: { accept: true } } }
 
       context 'role: guest' do
-        include_examples 'status code', 401
+        include_examples 'status code', 403
       end
 
       context 'role: user' do
@@ -20,22 +20,22 @@ RSpec.feature 'vote requests', type: :request do
 
         context 'state is :accepted' do
           let(:state) { :accepted }
-          include_examples 'status code', 401
+          include_examples 'status code', 403
         end
 
         context 'state is :archived' do
           let(:state) { :archived }
-          include_examples 'status code', 401
+          include_examples 'status code', 403
         end
 
         context 'state is :denied' do
           let(:state) { :denied }
-          include_examples 'status code', 401
+          include_examples 'status code', 403
         end
 
         context 'state is :disputed' do
           let(:state) { :disputed }
-          include_examples 'status code', 401
+          include_examples 'status code', 403
         end
       end
 

--- a/spec/support/shared_examples/login_helpers.rb
+++ b/spec/support/shared_examples/login_helpers.rb
@@ -1,7 +1,7 @@
 RSpec.shared_examples_for 'status code' do |status|
   description = case status
                 when 404 then ' (:not_found)'
-                when 401 then ' (:unauthorized)'
+                when 403 then ' (:forbidden)'
                 end
 
   it "returns status code #{status}#{description}" do


### PR DESCRIPTION
[401 is not appropriate, neither is 302](https://stackoverflow.com/a/22944878/2235594). Instead, use 403 unauthorized.

Also, you can read the httpstatuses of [401](https://httpstatuses.com/401) and [403](https://httpstatuses.com/401). Even though many do not implement the convention, we should do this.